### PR TITLE
Fix 'DeprecationWarning: There is no current event loop' in Python 3.10

### DIFF
--- a/poller.py
+++ b/poller.py
@@ -53,7 +53,7 @@ class uGitClientProtocol:
 if __name__ == '__main__':
     os.chdir(C['client'].get('repository', '.'))
     logging.basicConfig(format='%(asctime)s %(message)s', level = int(C['client']['logging']))
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     while True:
         connect = loop.create_datagram_endpoint(
             lambda: uGitClientProtocol(loop),

--- a/server.py
+++ b/server.py
@@ -27,7 +27,7 @@ class uGitServerProtocol:
 if __name__ == '__main__':
     os.chdir(C['server'].get('repository', '.'))
     logging.basicConfig(format='%(asctime)s %(message)s', level = int(C['server']['logging']))
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     logging.info("Starting uGitStat UDP server")
     listen = loop.create_datagram_endpoint(
         uGitServerProtocol, local_addr=(C['server']['host'], 19798))


### PR DESCRIPTION
Deprecated since version 3.10: Deprecation warning is emitted if there is no running event loop. In future Python releases, this function will be an alias of [get_running_loop()](https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_running_loop). 
I used asyncio.new_event_loop() instead of get_event_loop(), which should solve the problem. Everything works for me with one client.